### PR TITLE
Optimized code to reduce more than 300kb vendor size when compiled chain3

### DIFF
--- a/lib/utils/account.js
+++ b/lib/utils/account.js
@@ -1,40 +1,32 @@
 "use strict";
 
-var _ = require("underscore");
-var Account = require("eth-lib/lib/account");
-var Hash = require("eth-lib/lib/hash");
+var Account = require("./eth-lib/account");
+var Hash = require("./eth-lib/hash");
 var RLP = require("eth-lib/lib/rlp");
-var Nat = require("eth-lib/lib/nat");
-var Bytes = require("eth-lib/lib/bytes");
-var cryp = (typeof global === 'undefined') ? require('crypto-browserify') : require('crypto');
+var Bytes = require("./eth-lib/bytes");
 var utils = require('./utils.js');
 var secp256k1 = require('secp256k1');
 var Buffer = require('safe-buffer').Buffer;
 var assert = require('assert');
 
-
-var isNot = function(value) {
-    return (_.isUndefined(value) || _.isNull(value));
-};
-
 //To fix an error of 2 leading 0s
 var trimLeadingZero = function (hex) {
-    while (hex && hex.startsWith('0x00')) {
-        hex = '0x' + hex.slice(4);
-    }
-    return hex;
+  while (hex && hex.startsWith('0x00')) {
+    hex = '0x' + hex.slice(4);
+  }
+  return hex;
 };
 
 /*
  * This function is to resolve the issue 
  * https://github.com/ethereum/web3.js/issues/1170
  * 
-*/
+ */
 var makeEven = function (hex) {
-    if(hex.length % 2 === 1) {
-        hex = hex.replace('0x', '0x0');
-    }
-    return hex;
+  if (hex.length % 2 === 1) {
+    hex = hex.replace('0x', '0x0');
+  }
+  return hex;
 };
 
 /**
@@ -68,7 +60,7 @@ function isHexString(value, length) {
   return true;
 }
 
-function isHexPrefixed (str) {
+function isHexPrefixed(str) {
   return str.slice(0, 2) === '0x';
 }
 
@@ -77,7 +69,7 @@ function isHexPrefixed (str) {
  * @param {String} value
  * @return {String} output
  */
-function stripHexPrefix (str) {
+function stripHexPrefix(str) {
   if (typeof str !== 'string') {
     return str;
   }
@@ -90,7 +82,7 @@ function stripHexPrefix (str) {
  * @return {String} output
  */
 
-function padToEven (a) {
+function padToEven(a) {
   if (a.length % 2) a = '0' + a
   return a
 }
@@ -99,7 +91,7 @@ function padToEven (a) {
  * Attempts to turn a value into a `Buffer`. As input it supports `Buffer`, `String`, `Number`, null/undefined, `BN` and other objects with a `toArray()` method.
  * @param {*} v the value
  */
-function toBuffer (v) {
+function toBuffer(v) {
   if (!Buffer.isBuffer(v)) {
     if (Array.isArray(v)) {
       v = Buffer.from(v)
@@ -128,7 +120,7 @@ function toBuffer (v) {
  * @param {Buffer} buf
  * @return {String}
  */
-function bufferToHex (buf) {
+function bufferToHex(buf) {
   buf = toBuffer(buf)
   return '0x' + buf.toString('hex')
 }
@@ -136,8 +128,8 @@ function bufferToHex (buf) {
 
 /*
  * RLP usage, the i 
-*/
-function intToHex (i) {
+ */
+function intToHex(i) {
   var hex = i.toString(16)
   if (hex.length % 2) {
     hex = '0' + hex
@@ -148,8 +140,8 @@ function intToHex (i) {
 
 /*
  * Transfer
-*/
-function intToBuffer (i) {
+ */
+function intToBuffer(i) {
   var hex = intToHex(i)
   return new Buffer(hex, 'hex')
 }
@@ -160,13 +152,13 @@ function intToBuffer (i) {
  * @param {Buffer} privateKey
  * @return {Object}
  */
-function ecsign (msgHash, privateKeyStr) {
+function ecsign(msgHash, privateKeyStr) {
 
   //Convert the input string to Buffer
   if (typeof msgHash === 'string') {
-      if (isHexString(msgHash)) {
-        msgHash = Buffer.from(makeEven(stripHexPrefix(msgHash)), 'hex')
-      } 
+    if (isHexString(msgHash)) {
+      msgHash = Buffer.from(makeEven(stripHexPrefix(msgHash)), 'hex')
+    }
   }
 
   var privateKey = new Buffer(privateKeyStr, 'hex');
@@ -187,7 +179,7 @@ function ecsign (msgHash, privateKeyStr) {
  * @param {Number} bytes  the number of bytes the buffer should be
  * @return {Buffer}
  */
-function zeros (bytes) {
+function zeros(bytes) {
   return Buffer.allocUnsafe(bytes).fill(0);
 };
 
@@ -200,7 +192,7 @@ function zeros (bytes) {
  * @param {Boolean} [right=false] whether to start padding form the left or right
  * @return {Buffer|Array}
  */
-function setLength (msg, length, right) {
+function setLength(msg, length, right) {
   var buf = zeros(length);
   msg = toBuffer(msg);
   if (right) {
@@ -246,11 +238,11 @@ exports.ecrecover = function (msgHash, v, r, s) {
  * @param {String} signedData
  * @param {String} srcAddr
  * @return {Boolean}
-*/
-function verifyMcSignature (message, signedData, srcAddr) {
+ */
+function verifyMcSignature(message, signedData, srcAddr) {
 
   // Need to add MOAC prefix to the message
-  var prefixMsg= addPrefixToMessage(toBuffer(message));
+  var prefixMsg = addPrefixToMessage(toBuffer(message));
 
   // do Hash
   var msgHash = Hash.keccak256(prefixMsg);
@@ -259,12 +251,12 @@ function verifyMcSignature (message, signedData, srcAddr) {
   try {
 
     var recoverAddr = Account.recover(msgHash, signedData).toLowerCase();
-      // console.log(assert.equal(recoverAddr.toUpperCase(), srcAddr.toUpperCase()));
-      assert.equal(recoverAddr, srcAddr.toLowerCase());
-      if ( recoverAddr == srcAddr.toLowerCase()){
+    // console.log(assert.equal(recoverAddr.toUpperCase(), srcAddr.toUpperCase()));
+    assert.equal(recoverAddr, srcAddr.toLowerCase());
+    if (recoverAddr == srcAddr.toLowerCase()) {
       // console.log("Verify address the same: true");
-        return true;
-     }else{
+      return true;
+    } else {
       // console.log("Veify found diff addr: false");
       return false;
 
@@ -292,17 +284,17 @@ function verifyMcSignature (message, signedData, srcAddr) {
  * 27: 0x74 = 116 = 't' : actual inpu byte array;
  * @param {Buffer} 
  * @return {Buffer} 
-*/
+ */
 function addPrefixToMessage(message) {
   //Header: \x19MoacNode Signed Message:\n
   //25 77 111 97 99 78 111 100 101 32 83 105 103 110 101 100 32 77 101 115 115 97 103 101 58 10
   var prefix = toBuffer('0x194d6f61634e6f6465205369676e6564204d6573736167653a0a');
   var msgLen = message.length.toString();
 
-  var lenBuf= new Buffer(msgLen.length);
+  var lenBuf = new Buffer(msgLen.length);
 
   // Convert the string length to ASCII string array
-  for (var i = 0; i < msgLen.length; i ++){
+  for (var i = 0; i < msgLen.length; i++) {
     lenBuf[i] = msgLen.charCodeAt(i);
   }
 
@@ -320,16 +312,16 @@ function addPrefixToMessage(message) {
  */
 function signMcMessage(message, privateKey) {
   // console.log("toBuffer:", toBuffer(message));
-  var prefixMsg= addPrefixToMessage(toBuffer(message));//Buffer.concat([prefix, toBuffer(message)]);
+  var prefixMsg = addPrefixToMessage(toBuffer(message)); //Buffer.concat([prefix, toBuffer(message)]);
 
-  var inHash = Hash.keccak256(prefixMsg);//
+  var inHash = Hash.keccak256(prefixMsg); //
 
   var newsign = ecsign(inHash, stripHexPrefix(privateKey));
-  var  v = trimLeadingZero(makeEven(bufferToHex(newsign.v)));
-  var  r = trimLeadingZero(makeEven(bufferToHex(newsign.r)));
-  var  s = trimLeadingZero(makeEven(bufferToHex(newsign.s)));
+  var v = trimLeadingZero(makeEven(bufferToHex(newsign.v)));
+  var r = trimLeadingZero(makeEven(bufferToHex(newsign.r)));
+  var s = trimLeadingZero(makeEven(bufferToHex(newsign.s)));
 
-  return r+stripHexPrefix(s)+stripHexPrefix(v);
+  return r + stripHexPrefix(s) + stripHexPrefix(v);
 }
 
 /* 
@@ -343,100 +335,101 @@ function signMcMessage(message, privateKey) {
  *                  mc.sendRawTransaction
  * 
  * 
-*/
+ */
 var signTransaction = function (tx, privateKey) {
 
   if (tx.chainId < 1) {
-      return new Error('"Chain ID" is invalid');
+    return new Error('"Chain ID" is invalid');
   }
 
   if (!tx.gas && !tx.gasLimit) {
-     return new Error('"gas" is missing');
+    return new Error('"gas" is missing');
   }
 
-  if (tx.nonce  < 0 ||
-      tx.gasLimit  < 0 ||
-      tx.gasPrice  < 0 ||
-      tx.chainId  < 0) {
-      return new Error('Gas, gasPrice, nonce or chainId is lower than 0');
+  if (tx.nonce < 0 ||
+    tx.gasLimit < 0 ||
+    tx.gasPrice < 0 ||
+    tx.chainId < 0) {
+    return new Error('Gas, gasPrice, nonce or chainId is lower than 0');
   }
 
 
   //Sharding Flag can be 0, 1, 2
   //If input has not sharding flag, set it to 0 as global TX.
-  if (tx.shardingFlag == undefined){
-      tx.shardingFlag = 0;
+  if (tx.shardingFlag == undefined) {
+    tx.shardingFlag = 0;
   }
 
   try {
-      //Make sure all the number fields are in HEX format
+    //Make sure all the number fields are in HEX format
 
-      var transaction = tx;
-      transaction.to = tx.to || '0x';//Can be zero, for contract creation
-      transaction.data = tx.data || '0x';//can be zero for general TXs
-      transaction.value = tx.value || '0x';//can be zero for contract call
-      transaction.chainId = utils.numberToHex(tx.chainId);
-      transaction.shardingFlag = utils.numberToHex(tx.shardingFlag);
-      transaction.systemContract = '0x0';//System contract flag, always = 0
-      transaction.via = tx.via || '0x'; //vnode subchain address
+    var transaction = tx;
+    transaction.to = tx.to || '0x'; //Can be zero, for contract creation
+    transaction.data = tx.data || '0x'; //can be zero for general TXs
+    transaction.value = tx.value || '0x'; //can be zero for contract call
+    transaction.chainId = utils.numberToHex(tx.chainId);
+    transaction.shardingFlag = utils.numberToHex(tx.shardingFlag);
+    transaction.systemContract = '0x0'; //System contract flag, always = 0
+    transaction.via = tx.via || '0x'; //vnode subchain address
 
-      //Encode the TX for signature
-      //   type txdata struct {
-      // AccountNonce uint64          `json:"nonce"    gencodec:"required"`
-      // SystemContract uint64          `json:"syscnt" gencodec:"required"`
-      // Price        *big.Int        `json:"gasPrice" gencodec:"required"`
-      // GasLimit     *big.Int        `json:"gas"      gencodec:"required"`
-      //   // nil means contract creation
-      // Amount       *big.Int        `json:"value"    gencodec:"required"`
-      // Payload      []byte          `json:"input"    gencodec:"required"`
-      // ShardingFlag uint64 `json:"shardingFlag" gencodec:"required"`
-      // Via            *common.Address `json:"to"       rlp:"nil"`
+    //Encode the TX for signature
+    //   type txdata struct {
+    // AccountNonce uint64          `json:"nonce"    gencodec:"required"`
+    // SystemContract uint64          `json:"syscnt" gencodec:"required"`
+    // Price        *big.Int        `json:"gasPrice" gencodec:"required"`
+    // GasLimit     *big.Int        `json:"gas"      gencodec:"required"`
+    //   // nil means contract creation
+    // Amount       *big.Int        `json:"value"    gencodec:"required"`
+    // Payload      []byte          `json:"input"    gencodec:"required"`
+    // ShardingFlag uint64 `json:"shardingFlag" gencodec:"required"`
+    // Via            *common.Address `json:"to"       rlp:"nil"`
 
-      // // Signature values
-      // V *big.Int `json:"v" gencodec:"required"`
-      // R *big.Int `json:"r" gencodec:"required"`
-      // S *big.Int `json:"s" gencodec:"required"`
+    // // Signature values
+    // V *big.Int `json:"v" gencodec:"required"`
+    // R *big.Int `json:"r" gencodec:"required"`
+    // S *big.Int `json:"s" gencodec:"required"`
 
-      var rlpEncoded = RLP.encode([
-          Bytes.fromNat(transaction.nonce),
-          Bytes.fromNat(transaction.systemContract),
-          Bytes.fromNat(transaction.gasPrice),
-          Bytes.fromNat(transaction.gasLimit),
-          transaction.to.toLowerCase(),
-          Bytes.fromNat(transaction.value),
-          transaction.data,
-          Bytes.fromNat(transaction.shardingFlag),
-          // transaction.via.toLowerCase()]);
-          transaction.via.toLowerCase(),
-          Bytes.fromNat(transaction.chainId),
-          "0x",
-          "0x"]);
+    var rlpEncoded = RLP.encode([
+      Bytes.fromNat(transaction.nonce),
+      Bytes.fromNat(transaction.systemContract),
+      Bytes.fromNat(transaction.gasPrice),
+      Bytes.fromNat(transaction.gasLimit),
+      transaction.to.toLowerCase(),
+      Bytes.fromNat(transaction.value),
+      transaction.data,
+      Bytes.fromNat(transaction.shardingFlag),
+      // transaction.via.toLowerCase()]);
+      transaction.via.toLowerCase(),
+      Bytes.fromNat(transaction.chainId),
+      "0x",
+      "0x"
+    ]);
 
-      var hash = Hash.keccak256(rlpEncoded);
+    var hash = Hash.keccak256(rlpEncoded);
 
-      // for MOAC, keep 9 fields instead of 6
-      var vPos = 9;
-      //Sign the hash with the private key to produce the
-      //V, R, S
-      var newsign = ecsign(hash, stripHexPrefix(privateKey));
+    // for MOAC, keep 9 fields instead of 6
+    var vPos = 9;
+    //Sign the hash with the private key to produce the
+    //V, R, S
+    var newsign = ecsign(hash, stripHexPrefix(privateKey));
 
-      var rawTx = RLP.decode(rlpEncoded).slice(0,vPos+3);
+    var rawTx = RLP.decode(rlpEncoded).slice(0, vPos + 3);
 
-      //Replace the V field with chainID info
-      var newV = newsign.v + 8 + transaction.chainId *2;
+    //Replace the V field with chainID info
+    var newV = newsign.v + 8 + transaction.chainId * 2;
 
-      // Add trimLeadingZero to avoid '0x00' after makeEven
-      // dont allow uneven r,s,v values
-      rawTx[vPos] = trimLeadingZero(makeEven(bufferToHex(newV)));
-      rawTx[vPos+1] = trimLeadingZero(makeEven(bufferToHex(newsign.r)));
-      rawTx[vPos+2] = trimLeadingZero(makeEven(bufferToHex(newsign.s)));
+    // Add trimLeadingZero to avoid '0x00' after makeEven
+    // dont allow uneven r,s,v values
+    rawTx[vPos] = trimLeadingZero(makeEven(bufferToHex(newV)));
+    rawTx[vPos + 1] = trimLeadingZero(makeEven(bufferToHex(newsign.r)));
+    rawTx[vPos + 2] = trimLeadingZero(makeEven(bufferToHex(newsign.s)));
 
-      var rawTransaction = RLP.encode(rawTx);
+    var rawTransaction = RLP.encode(rawTx);
 
 
-  } catch(e) {
+  } catch (e) {
 
-      return e;
+    return e;
   }
 
   return rawTransaction;
@@ -444,8 +437,8 @@ var signTransaction = function (tx, privateKey) {
 
 
 module.exports = {
-  toBuffer:toBuffer,
-    signTransaction: signTransaction,
-    signMcMessage: signMcMessage,
-    verifyMcSignature: verifyMcSignature
+  toBuffer: toBuffer,
+  signTransaction: signTransaction,
+  signMcMessage: signMcMessage,
+  verifyMcSignature: verifyMcSignature
 };

--- a/lib/utils/eth-lib/account.js
+++ b/lib/utils/eth-lib/account.js
@@ -1,0 +1,119 @@
+var _slicedToArray = function () {
+  function sliceIterator(arr, i) {
+    var _arr = [];
+    var _n = true;
+    var _d = false;
+    var _e = undefined;
+    try {
+      for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
+        _arr.push(_s.value);
+        if (i && _arr.length === i) break;
+      }
+    } catch (err) {
+      _d = true;
+      _e = err;
+    } finally {
+      try {
+        if (!_n && _i["return"]) _i["return"]();
+      } finally {
+        if (_d) throw _e;
+      }
+    }
+    return _arr;
+  }
+  return function (arr, i) {
+    if (Array.isArray(arr)) {
+      return arr;
+    } else if (Symbol.iterator in Object(arr)) {
+      return sliceIterator(arr, i);
+    } else {
+      throw new TypeError("Invalid attempt to destructure non-iterable instance");
+    }
+  };
+}();
+
+var Bytes = require("./bytes");
+var Nat = require("./nat");
+var elliptic = require("elliptic");
+var secp256k1 = new elliptic.ec("secp256k1"); // eslint-disable-line
+
+var _require = require("./hash"),
+  keccak256 = _require.keccak256,
+  keccak256s = _require.keccak256s;
+
+var create = function create(entropy) {
+  var innerHex = keccak256(Bytes.concat(Bytes.random(32), entropy || Bytes.random(32)));
+  var middleHex = Bytes.concat(Bytes.concat(Bytes.random(32), innerHex), Bytes.random(32));
+  var outerHex = keccak256(middleHex);
+  return fromPrivate(outerHex);
+};
+
+var toChecksum = function toChecksum(address) {
+  var addressHash = keccak256s(address.slice(2));
+  var checksumAddress = "0x";
+  for (var i = 0; i < 40; i++) {
+    checksumAddress += parseInt(addressHash[i + 2], 16) > 7 ? address[i + 2].toUpperCase() : address[i + 2];
+  }
+  return checksumAddress;
+};
+
+var fromPrivate = function fromPrivate(privateKey) {
+  var buffer = new Buffer(privateKey.slice(2), "hex");
+  var ecKey = secp256k1.keyFromPrivate(buffer);
+  var publicKey = "0x" + ecKey.getPublic(false, 'hex').slice(2);
+  var publicHash = keccak256(publicKey);
+  var address = toChecksum("0x" + publicHash.slice(-40));
+  return {
+    address: address,
+    privateKey: privateKey
+  };
+};
+
+var encodeSignature = function encodeSignature(_ref) {
+  var _ref2 = _slicedToArray(_ref, 3),
+    v = _ref2[0],
+    r = Bytes.pad(32, _ref2[1]),
+    s = Bytes.pad(32, _ref2[2]);
+
+  return Bytes.flatten([r, s, v]);
+};
+
+var decodeSignature = function decodeSignature(hex) {
+  return [Bytes.slice(64, Bytes.length(hex), hex), Bytes.slice(0, 32, hex), Bytes.slice(32, 64, hex)];
+};
+
+var makeSigner = function makeSigner(addToV) {
+  return function (hash, privateKey) {
+    var signature = secp256k1.keyFromPrivate(new Buffer(privateKey.slice(2), "hex")).sign(new Buffer(hash.slice(2), "hex"), {
+      canonical: true
+    });
+    return encodeSignature([Nat.fromString(Bytes.fromNumber(addToV + signature.recoveryParam)), Bytes.pad(32, Bytes.fromNat("0x" + signature.r.toString(16))), Bytes.pad(32, Bytes.fromNat("0x" + signature.s.toString(16)))]);
+  };
+};
+
+var sign = makeSigner(27); // v=27|28 instead of 0|1...
+
+var recover = function recover(hash, signature) {
+  var vals = decodeSignature(signature);
+  var vrs = {
+    v: Bytes.toNumber(vals[0]),
+    r: vals[1].slice(2),
+    s: vals[2].slice(2)
+  };
+  var ecPublicKey = secp256k1.recoverPubKey(new Buffer(hash.slice(2), "hex"), vrs, vrs.v < 2 ? vrs.v : 1 - vrs.v % 2); // because odd vals mean v=0... sadly that means v=0 means v=1... I hate that
+  var publicKey = "0x" + ecPublicKey.encode("hex", false).slice(2);
+  var publicHash = keccak256(publicKey);
+  var address = toChecksum("0x" + publicHash.slice(-40));
+  return address;
+};
+
+module.exports = {
+  create: create,
+  toChecksum: toChecksum,
+  fromPrivate: fromPrivate,
+  sign: sign,
+  makeSigner: makeSigner,
+  recover: recover,
+  encodeSignature: encodeSignature,
+  decodeSignature: decodeSignature
+};

--- a/lib/utils/eth-lib/bytes.js
+++ b/lib/utils/eth-lib/bytes.js
@@ -1,0 +1,180 @@
+var at = function at(bytes, index) {
+  return parseInt(bytes.slice(index * 2 + 2, index * 2 + 4), 16);
+};
+
+var length = function length(a) {
+  return (a.length - 2) / 2;
+};
+
+var flatten = function flatten(a) {
+  return "0x" + a.reduce(function (r, s) {
+    return r + s.slice(2);
+  }, "");
+};
+
+var slice = function slice(i, j, bs) {
+  return "0x" + bs.slice(i * 2 + 2, j * 2 + 2);
+};
+
+var reverse = function reverse(hex) {
+  var rev = "0x";
+  for (var i = 0, l = length(hex); i < l; ++i) {
+    rev += hex.slice((l - i) * 2, (l - i + 1) * 2);
+  }
+  return rev;
+};
+
+var pad = function pad(l, hex) {
+  return hex.length === l * 2 + 2 ? hex : pad(l, "0x" + "0" + hex.slice(2));
+};
+
+var padRight = function padRight(l, hex) {
+  return hex.length === l * 2 + 2 ? hex : padRight(l, hex + "0");
+};
+
+var toArray = function toArray(hex) {
+  var arr = [];
+  for (var i = 2, l = hex.length; i < l; i += 2) {
+    arr.push(parseInt(hex.slice(i, i + 2), 16));
+  }
+  return arr;
+};
+
+var fromArray = function fromArray(arr) {
+  var hex = "0x";
+  for (var i = 0, l = arr.length; i < l; ++i) {
+    var b = arr[i];
+    hex += (b < 16 ? "0" : "") + b.toString(16);
+  }
+  return hex;
+};
+
+var toUint8Array = function toUint8Array(hex) {
+  return new Uint8Array(toArray(hex));
+};
+
+var fromUint8Array = function fromUint8Array(arr) {
+  return fromArray([].slice.call(arr, 0));
+};
+
+var fromNumber = function fromNumber(num) {
+  var hex = num.toString(16);
+  return hex.length % 2 === 0 ? "0x" + hex : "0x0" + hex;
+};
+
+var toNumber = function toNumber(hex) {
+  return parseInt(hex.slice(2), 16);
+};
+
+var concat = function concat(a, b) {
+  return a.concat(b.slice(2));
+};
+
+var fromNat = function fromNat(bn) {
+  return bn === "0x0" ? "0x" : bn.length % 2 === 0 ? bn : "0x0" + bn.slice(2);
+};
+
+var toNat = function toNat(bn) {
+  return bn[2] === "0" ? "0x" + bn.slice(3) : bn;
+};
+
+var fromAscii = function fromAscii(ascii) {
+  var hex = "0x";
+  for (var i = 0; i < ascii.length; ++i) {
+    hex += ("00" + ascii.charCodeAt(i).toString(16)).slice(-2);
+  }
+  return hex;
+};
+
+var toAscii = function toAscii(hex) {
+  var ascii = "";
+  for (var i = 2; i < hex.length; i += 2) {
+    ascii += String.fromCharCode(parseInt(hex.slice(i, i + 2), 16));
+  }
+  return ascii;
+};
+
+// From https://gist.github.com/pascaldekloe/62546103a1576803dade9269ccf76330
+var fromString = function fromString(s) {
+  var makeByte = function makeByte(uint8) {
+    var b = uint8.toString(16);
+    return b.length < 2 ? "0" + b : b;
+  };
+  var bytes = "0x";
+  for (var ci = 0; ci != s.length; ci++) {
+    var c = s.charCodeAt(ci);
+    if (c < 128) {
+      bytes += makeByte(c);
+      continue;
+    }
+    if (c < 2048) {
+      bytes += makeByte(c >> 6 | 192);
+    } else {
+      if (c > 0xd7ff && c < 0xdc00) {
+        if (++ci == s.length) return null;
+        var c2 = s.charCodeAt(ci);
+        if (c2 < 0xdc00 || c2 > 0xdfff) return null;
+        c = 0x10000 + ((c & 0x03ff) << 10) + (c2 & 0x03ff);
+        bytes += makeByte(c >> 18 | 240);
+        bytes += makeByte(c >> 12 & 63 | 128);
+      } else {
+        // c <= 0xffff
+        bytes += makeByte(c >> 12 | 224);
+      }
+      bytes += makeByte(c >> 6 & 63 | 128);
+    }
+    bytes += makeByte(c & 63 | 128);
+  }
+  return bytes;
+};
+
+var toString = function toString(bytes) {
+  var s = '';
+  var i = 0;
+  var l = length(bytes);
+  while (i < l) {
+    var c = at(bytes, i++);
+    if (c > 127) {
+      if (c > 191 && c < 224) {
+        if (i >= l) return null;
+        c = (c & 31) << 6 | at(bytes, i) & 63;
+      } else if (c > 223 && c < 240) {
+        if (i + 1 >= l) return null;
+        c = (c & 15) << 12 | (at(bytes, i) & 63) << 6 | at(bytes, ++i) & 63;
+      } else if (c > 239 && c < 248) {
+        if (i + 2 >= l) return null;
+        c = (c & 7) << 18 | (at(bytes, i) & 63) << 12 | (at(bytes, ++i) & 63) << 6 | at(bytes, ++i) & 63;
+      } else return null;
+      ++i;
+    }
+    if (c <= 0xffff) s += String.fromCharCode(c);
+    else if (c <= 0x10ffff) {
+      c -= 0x10000;
+      s += String.fromCharCode(c >> 10 | 0xd800);
+      s += String.fromCharCode(c & 0x3FF | 0xdc00);
+    } else return null;
+  }
+  return s;
+};
+
+module.exports = {
+  length: length,
+  concat: concat,
+  flatten: flatten,
+  slice: slice,
+  reverse: reverse,
+  pad: pad,
+  padRight: padRight,
+  fromAscii: fromAscii,
+  toAscii: toAscii,
+  fromString: fromString,
+  toString: toString,
+  fromNumber: fromNumber,
+  toNumber: toNumber,
+  fromNat: fromNat,
+  toNat: toNat,
+  fromArray: fromArray,
+  toArray: toArray,
+  fromUint8Array: fromUint8Array,
+  toUint8Array: toUint8Array
+};

--- a/lib/utils/eth-lib/hash.js
+++ b/lib/utils/eth-lib/hash.js
@@ -1,0 +1,339 @@
+// This was ported from https://github.com/emn178/js-sha3, with some minor
+// modifications and pruning. It is licensed under MIT:
+//
+// Copyright 2015-2016 Chen, Yi-Cyuan
+//  
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var HEX_CHARS = '0123456789abcdef'.split('');
+var KECCAK_PADDING = [1, 256, 65536, 16777216];
+var SHIFT = [0, 8, 16, 24];
+var RC = [1, 0, 32898, 0, 32906, 2147483648, 2147516416, 2147483648, 32907, 0, 2147483649, 0, 2147516545, 2147483648, 32777, 2147483648, 138, 0, 136, 0, 2147516425, 0, 2147483658, 0, 2147516555, 0, 139, 2147483648, 32905, 2147483648, 32771, 2147483648, 32770, 2147483648, 128, 2147483648, 32778, 0, 2147483658, 2147483648, 2147516545, 2147483648, 32896, 2147483648, 2147483649, 0, 2147516424, 2147483648];
+
+var Keccak = function Keccak(bits) {
+  return {
+    blocks: [],
+    reset: true,
+    block: 0,
+    start: 0,
+    blockCount: 1600 - (bits << 1) >> 5,
+    outputBlocks: bits >> 5,
+    s: function (s) {
+      return [].concat(s, s, s, s, s);
+    }([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+  };
+};
+
+var update = function update(state, message) {
+  var length = message.length,
+      blocks = state.blocks,
+      byteCount = state.blockCount << 2,
+      blockCount = state.blockCount,
+      outputBlocks = state.outputBlocks,
+      s = state.s,
+      index = 0,
+      i,
+      code;
+
+  // update
+  while (index < length) {
+    if (state.reset) {
+      state.reset = false;
+      blocks[0] = state.block;
+      for (i = 1; i < blockCount + 1; ++i) {
+        blocks[i] = 0;
+      }
+    }
+    if (typeof message !== "string") {
+      for (i = state.start; index < length && i < byteCount; ++index) {
+        blocks[i >> 2] |= message[index] << SHIFT[i++ & 3];
+      }
+    } else {
+      for (i = state.start; index < length && i < byteCount; ++index) {
+        code = message.charCodeAt(index);
+        if (code < 0x80) {
+          blocks[i >> 2] |= code << SHIFT[i++ & 3];
+        } else if (code < 0x800) {
+          blocks[i >> 2] |= (0xc0 | code >> 6) << SHIFT[i++ & 3];
+          blocks[i >> 2] |= (0x80 | code & 0x3f) << SHIFT[i++ & 3];
+        } else if (code < 0xd800 || code >= 0xe000) {
+          blocks[i >> 2] |= (0xe0 | code >> 12) << SHIFT[i++ & 3];
+          blocks[i >> 2] |= (0x80 | code >> 6 & 0x3f) << SHIFT[i++ & 3];
+          blocks[i >> 2] |= (0x80 | code & 0x3f) << SHIFT[i++ & 3];
+        } else {
+          code = 0x10000 + ((code & 0x3ff) << 10 | message.charCodeAt(++index) & 0x3ff);
+          blocks[i >> 2] |= (0xf0 | code >> 18) << SHIFT[i++ & 3];
+          blocks[i >> 2] |= (0x80 | code >> 12 & 0x3f) << SHIFT[i++ & 3];
+          blocks[i >> 2] |= (0x80 | code >> 6 & 0x3f) << SHIFT[i++ & 3];
+          blocks[i >> 2] |= (0x80 | code & 0x3f) << SHIFT[i++ & 3];
+        }
+      }
+    }
+    state.lastByteIndex = i;
+    if (i >= byteCount) {
+      state.start = i - byteCount;
+      state.block = blocks[blockCount];
+      for (i = 0; i < blockCount; ++i) {
+        s[i] ^= blocks[i];
+      }
+      f(s);
+      state.reset = true;
+    } else {
+      state.start = i;
+    }
+  }
+
+  // finalize
+  i = state.lastByteIndex;
+  blocks[i >> 2] |= KECCAK_PADDING[i & 3];
+  if (state.lastByteIndex === byteCount) {
+    blocks[0] = blocks[blockCount];
+    for (i = 1; i < blockCount + 1; ++i) {
+      blocks[i] = 0;
+    }
+  }
+  blocks[blockCount - 1] |= 0x80000000;
+  for (i = 0; i < blockCount; ++i) {
+    s[i] ^= blocks[i];
+  }
+  f(s);
+
+  // toString
+  var hex = '',
+      i = 0,
+      j = 0,
+      block;
+  while (j < outputBlocks) {
+    for (i = 0; i < blockCount && j < outputBlocks; ++i, ++j) {
+      block = s[i];
+      hex += HEX_CHARS[block >> 4 & 0x0F] + HEX_CHARS[block & 0x0F] + HEX_CHARS[block >> 12 & 0x0F] + HEX_CHARS[block >> 8 & 0x0F] + HEX_CHARS[block >> 20 & 0x0F] + HEX_CHARS[block >> 16 & 0x0F] + HEX_CHARS[block >> 28 & 0x0F] + HEX_CHARS[block >> 24 & 0x0F];
+    }
+    if (j % blockCount === 0) {
+      f(s);
+      i = 0;
+    }
+  }
+  return "0x" + hex;
+};
+
+var f = function f(s) {
+  var h, l, n, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17, b18, b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30, b31, b32, b33, b34, b35, b36, b37, b38, b39, b40, b41, b42, b43, b44, b45, b46, b47, b48, b49;
+
+  for (n = 0; n < 48; n += 2) {
+    c0 = s[0] ^ s[10] ^ s[20] ^ s[30] ^ s[40];
+    c1 = s[1] ^ s[11] ^ s[21] ^ s[31] ^ s[41];
+    c2 = s[2] ^ s[12] ^ s[22] ^ s[32] ^ s[42];
+    c3 = s[3] ^ s[13] ^ s[23] ^ s[33] ^ s[43];
+    c4 = s[4] ^ s[14] ^ s[24] ^ s[34] ^ s[44];
+    c5 = s[5] ^ s[15] ^ s[25] ^ s[35] ^ s[45];
+    c6 = s[6] ^ s[16] ^ s[26] ^ s[36] ^ s[46];
+    c7 = s[7] ^ s[17] ^ s[27] ^ s[37] ^ s[47];
+    c8 = s[8] ^ s[18] ^ s[28] ^ s[38] ^ s[48];
+    c9 = s[9] ^ s[19] ^ s[29] ^ s[39] ^ s[49];
+
+    h = c8 ^ (c2 << 1 | c3 >>> 31);
+    l = c9 ^ (c3 << 1 | c2 >>> 31);
+    s[0] ^= h;
+    s[1] ^= l;
+    s[10] ^= h;
+    s[11] ^= l;
+    s[20] ^= h;
+    s[21] ^= l;
+    s[30] ^= h;
+    s[31] ^= l;
+    s[40] ^= h;
+    s[41] ^= l;
+    h = c0 ^ (c4 << 1 | c5 >>> 31);
+    l = c1 ^ (c5 << 1 | c4 >>> 31);
+    s[2] ^= h;
+    s[3] ^= l;
+    s[12] ^= h;
+    s[13] ^= l;
+    s[22] ^= h;
+    s[23] ^= l;
+    s[32] ^= h;
+    s[33] ^= l;
+    s[42] ^= h;
+    s[43] ^= l;
+    h = c2 ^ (c6 << 1 | c7 >>> 31);
+    l = c3 ^ (c7 << 1 | c6 >>> 31);
+    s[4] ^= h;
+    s[5] ^= l;
+    s[14] ^= h;
+    s[15] ^= l;
+    s[24] ^= h;
+    s[25] ^= l;
+    s[34] ^= h;
+    s[35] ^= l;
+    s[44] ^= h;
+    s[45] ^= l;
+    h = c4 ^ (c8 << 1 | c9 >>> 31);
+    l = c5 ^ (c9 << 1 | c8 >>> 31);
+    s[6] ^= h;
+    s[7] ^= l;
+    s[16] ^= h;
+    s[17] ^= l;
+    s[26] ^= h;
+    s[27] ^= l;
+    s[36] ^= h;
+    s[37] ^= l;
+    s[46] ^= h;
+    s[47] ^= l;
+    h = c6 ^ (c0 << 1 | c1 >>> 31);
+    l = c7 ^ (c1 << 1 | c0 >>> 31);
+    s[8] ^= h;
+    s[9] ^= l;
+    s[18] ^= h;
+    s[19] ^= l;
+    s[28] ^= h;
+    s[29] ^= l;
+    s[38] ^= h;
+    s[39] ^= l;
+    s[48] ^= h;
+    s[49] ^= l;
+
+    b0 = s[0];
+    b1 = s[1];
+    b32 = s[11] << 4 | s[10] >>> 28;
+    b33 = s[10] << 4 | s[11] >>> 28;
+    b14 = s[20] << 3 | s[21] >>> 29;
+    b15 = s[21] << 3 | s[20] >>> 29;
+    b46 = s[31] << 9 | s[30] >>> 23;
+    b47 = s[30] << 9 | s[31] >>> 23;
+    b28 = s[40] << 18 | s[41] >>> 14;
+    b29 = s[41] << 18 | s[40] >>> 14;
+    b20 = s[2] << 1 | s[3] >>> 31;
+    b21 = s[3] << 1 | s[2] >>> 31;
+    b2 = s[13] << 12 | s[12] >>> 20;
+    b3 = s[12] << 12 | s[13] >>> 20;
+    b34 = s[22] << 10 | s[23] >>> 22;
+    b35 = s[23] << 10 | s[22] >>> 22;
+    b16 = s[33] << 13 | s[32] >>> 19;
+    b17 = s[32] << 13 | s[33] >>> 19;
+    b48 = s[42] << 2 | s[43] >>> 30;
+    b49 = s[43] << 2 | s[42] >>> 30;
+    b40 = s[5] << 30 | s[4] >>> 2;
+    b41 = s[4] << 30 | s[5] >>> 2;
+    b22 = s[14] << 6 | s[15] >>> 26;
+    b23 = s[15] << 6 | s[14] >>> 26;
+    b4 = s[25] << 11 | s[24] >>> 21;
+    b5 = s[24] << 11 | s[25] >>> 21;
+    b36 = s[34] << 15 | s[35] >>> 17;
+    b37 = s[35] << 15 | s[34] >>> 17;
+    b18 = s[45] << 29 | s[44] >>> 3;
+    b19 = s[44] << 29 | s[45] >>> 3;
+    b10 = s[6] << 28 | s[7] >>> 4;
+    b11 = s[7] << 28 | s[6] >>> 4;
+    b42 = s[17] << 23 | s[16] >>> 9;
+    b43 = s[16] << 23 | s[17] >>> 9;
+    b24 = s[26] << 25 | s[27] >>> 7;
+    b25 = s[27] << 25 | s[26] >>> 7;
+    b6 = s[36] << 21 | s[37] >>> 11;
+    b7 = s[37] << 21 | s[36] >>> 11;
+    b38 = s[47] << 24 | s[46] >>> 8;
+    b39 = s[46] << 24 | s[47] >>> 8;
+    b30 = s[8] << 27 | s[9] >>> 5;
+    b31 = s[9] << 27 | s[8] >>> 5;
+    b12 = s[18] << 20 | s[19] >>> 12;
+    b13 = s[19] << 20 | s[18] >>> 12;
+    b44 = s[29] << 7 | s[28] >>> 25;
+    b45 = s[28] << 7 | s[29] >>> 25;
+    b26 = s[38] << 8 | s[39] >>> 24;
+    b27 = s[39] << 8 | s[38] >>> 24;
+    b8 = s[48] << 14 | s[49] >>> 18;
+    b9 = s[49] << 14 | s[48] >>> 18;
+
+    s[0] = b0 ^ ~b2 & b4;
+    s[1] = b1 ^ ~b3 & b5;
+    s[10] = b10 ^ ~b12 & b14;
+    s[11] = b11 ^ ~b13 & b15;
+    s[20] = b20 ^ ~b22 & b24;
+    s[21] = b21 ^ ~b23 & b25;
+    s[30] = b30 ^ ~b32 & b34;
+    s[31] = b31 ^ ~b33 & b35;
+    s[40] = b40 ^ ~b42 & b44;
+    s[41] = b41 ^ ~b43 & b45;
+    s[2] = b2 ^ ~b4 & b6;
+    s[3] = b3 ^ ~b5 & b7;
+    s[12] = b12 ^ ~b14 & b16;
+    s[13] = b13 ^ ~b15 & b17;
+    s[22] = b22 ^ ~b24 & b26;
+    s[23] = b23 ^ ~b25 & b27;
+    s[32] = b32 ^ ~b34 & b36;
+    s[33] = b33 ^ ~b35 & b37;
+    s[42] = b42 ^ ~b44 & b46;
+    s[43] = b43 ^ ~b45 & b47;
+    s[4] = b4 ^ ~b6 & b8;
+    s[5] = b5 ^ ~b7 & b9;
+    s[14] = b14 ^ ~b16 & b18;
+    s[15] = b15 ^ ~b17 & b19;
+    s[24] = b24 ^ ~b26 & b28;
+    s[25] = b25 ^ ~b27 & b29;
+    s[34] = b34 ^ ~b36 & b38;
+    s[35] = b35 ^ ~b37 & b39;
+    s[44] = b44 ^ ~b46 & b48;
+    s[45] = b45 ^ ~b47 & b49;
+    s[6] = b6 ^ ~b8 & b0;
+    s[7] = b7 ^ ~b9 & b1;
+    s[16] = b16 ^ ~b18 & b10;
+    s[17] = b17 ^ ~b19 & b11;
+    s[26] = b26 ^ ~b28 & b20;
+    s[27] = b27 ^ ~b29 & b21;
+    s[36] = b36 ^ ~b38 & b30;
+    s[37] = b37 ^ ~b39 & b31;
+    s[46] = b46 ^ ~b48 & b40;
+    s[47] = b47 ^ ~b49 & b41;
+    s[8] = b8 ^ ~b0 & b2;
+    s[9] = b9 ^ ~b1 & b3;
+    s[18] = b18 ^ ~b10 & b12;
+    s[19] = b19 ^ ~b11 & b13;
+    s[28] = b28 ^ ~b20 & b22;
+    s[29] = b29 ^ ~b21 & b23;
+    s[38] = b38 ^ ~b30 & b32;
+    s[39] = b39 ^ ~b31 & b33;
+    s[48] = b48 ^ ~b40 & b42;
+    s[49] = b49 ^ ~b41 & b43;
+
+    s[0] ^= RC[n];
+    s[1] ^= RC[n + 1];
+  }
+};
+
+var keccak = function keccak(bits) {
+  return function (str) {
+    var msg;
+    if (str.slice(0, 2) === "0x") {
+      msg = [];
+      for (var i = 2, l = str.length; i < l; i += 2) {
+        msg.push(parseInt(str.slice(i, i + 2), 16));
+      }
+    } else {
+      msg = str;
+    }
+    return update(Keccak(bits, bits), msg);
+  };
+};
+
+module.exports = {
+  keccak256: keccak(256),
+  keccak512: keccak(512),
+  keccak256s: keccak(256),
+  keccak512s: keccak(512)
+};

--- a/lib/utils/eth-lib/nat.js
+++ b/lib/utils/eth-lib/nat.js
@@ -1,0 +1,64 @@
+var BN = require("bn.js");
+var Bytes = require("./bytes");
+
+var fromBN = function fromBN(bn) {
+  return "0x" + bn.toString("hex");
+};
+
+var toBN = function toBN(str) {
+  return new BN(str.slice(2), 16);
+};
+
+var fromString = function fromString(str) {
+  var bn = "0x" + (str.slice(0, 2) === "0x" ? new BN(str.slice(2), 16) : new BN(str, 10)).toString("hex");
+  return bn === "0x0" ? "0x" : bn;
+};
+
+var toEther = function toEther(wei) {
+  return toNumber(div(wei, fromString("10000000000"))) / 100000000;
+};
+
+var fromEther = function fromEther(eth) {
+  return mul(fromNumber(Math.floor(eth * 100000000)), fromString("10000000000"));
+};
+
+var toString = function toString(a) {
+  return toBN(a).toString(10);
+};
+
+var fromNumber = function fromNumber(a) {
+  return typeof a === "string" ? /^0x/.test(a) ? a : "0x" + a : "0x" + new BN(a).toString("hex");
+};
+
+var toNumber = function toNumber(a) {
+  return toBN(a).toNumber();
+};
+
+var toUint256 = function toUint256(a) {
+  return Bytes.pad(32, a);
+};
+
+var bin = function bin(method) {
+  return function (a, b) {
+    return fromBN(toBN(a)[method](toBN(b)));
+  };
+};
+
+var add = bin("add");
+var mul = bin("mul");
+var div = bin("div");
+var sub = bin("sub");
+
+module.exports = {
+  toString: toString,
+  fromString: fromString,
+  toNumber: toNumber,
+  fromNumber: fromNumber,
+  toEther: toEther,
+  fromEther: fromEther,
+  toUint256: toUint256,
+  add: add,
+  mul: mul,
+  div: div,
+  sub: sub
+};


### PR DESCRIPTION
I have a project used chain3, when i complied the source file with webpack.

Before I changed ``chain3/lib/util/account.js``  in the ``node_modules``,  the compiled file size as follow:
<img width="1063" alt="Screen Shot 2019-04-04 at 00 35 15" src="https://user-images.githubusercontent.com/12183493/55498454-411c1580-5676-11e9-920b-5d1e87e690d7.png">

After I updated ``chain3/lib/util/account.js``  in the ``node_modules``, the compiled file size as follow:
<img width="1060" alt="Screen Shot 2019-04-04 at 00 36 34" src="https://user-images.githubusercontent.com/12183493/55498519-67da4c00-5676-11e9-9892-456b0f25a083.png">

Reduced more than 300kb.
