### PR TITLE
fix formatter tuple crash & pass output data to callback for process self

### DIFF
--- a/lib/chain3/function.js
+++ b/lib/chain3/function.js
@@ -32,12 +32,12 @@ var sha3 = require('../utils/sha3');
 /**
  * This prototype should be used to call/sendTransaction to solidity functions
  */
-var SolidityFunction = function (mc, json, address) {
+var SolidityFunction = function(mc, json, address) {
     this._mc = mc;
-    this._inputTypes = json.inputs.map(function (i) {
+    this._inputTypes = json.inputs.map(function(i) {
         return i.type;
     });
-    this._outputTypes = json.outputs.map(function (i) {
+    this._outputTypes = json.outputs.map(function(i) {
         return i.type;
     });
     this._constant = json.constant;
@@ -46,14 +46,14 @@ var SolidityFunction = function (mc, json, address) {
     this._address = address;
 };
 
-SolidityFunction.prototype.extractCallback = function (args) {
+SolidityFunction.prototype.extractCallback = function(args) {
     if (utils.isFunction(args[args.length - 1])) {
         return args.pop(); // modify the args array!
     }
 };
 
-SolidityFunction.prototype.extractDefaultBlock = function (args) {
-    if (args.length > this._inputTypes.length && !utils.isObject(args[args.length -1])) {
+SolidityFunction.prototype.extractDefaultBlock = function(args) {
+    if (args.length > this._inputTypes.length && !utils.isObject(args[args.length - 1])) {
         return formatters.inputDefaultBlockNumberFormatter(args.pop()); // modify the args array!
     }
 };
@@ -65,13 +65,13 @@ SolidityFunction.prototype.extractDefaultBlock = function (args) {
  * @param {Array} arguments
  * @throws {Error} if it is not
  */
-SolidityFunction.prototype.validateArgs = function (args) {
-    var inputArgs = args.filter(function (a) {
-      // filter the options object but not arguments that are arrays
-      return !( (utils.isObject(a) === true) &&
-                (utils.isArray(a) === false) &&
-                (utils.isBigNumber(a) === false)
-              );
+SolidityFunction.prototype.validateArgs = function(args) {
+    var inputArgs = args.filter(function(a) {
+        // filter the options object but not arguments that are arrays
+        return !((utils.isObject(a) === true) &&
+            (utils.isArray(a) === false) &&
+            (utils.isBigNumber(a) === false)
+        );
     });
     if (inputArgs.length !== this._inputTypes.length) {
         throw errors.InvalidNumberOfSolidityArgs();
@@ -85,9 +85,9 @@ SolidityFunction.prototype.validateArgs = function (args) {
  * @param {Array} solidity function params
  * @param {Object} optional payload options
  */
-SolidityFunction.prototype.toPayload = function (args) {
+SolidityFunction.prototype.toPayload = function(args) {
     var options = {};
-    if (args.length > this._inputTypes.length && utils.isObject(args[args.length -1])) {
+    if (args.length > this._inputTypes.length && utils.isObject(args[args.length - 1])) {
         options = args[args.length - 1];
     }
     this.validateArgs(args);
@@ -102,12 +102,12 @@ SolidityFunction.prototype.toPayload = function (args) {
  * @method signature
  * @return {String} function signature
  */
-SolidityFunction.prototype.signature = function () {
+SolidityFunction.prototype.signature = function() {
     return sha3(this._name).slice(0, 8);
 };
 
 
-SolidityFunction.prototype.unpackOutput = function (output) {
+SolidityFunction.prototype.unpackOutput = function(output) {
     if (!output) {
         return;
     }
@@ -127,8 +127,8 @@ SolidityFunction.prototype.unpackOutput = function (output) {
  *   error and result.
  * @return {String} output bytes
  */
-SolidityFunction.prototype.call = function () {
-    var args = Array.prototype.slice.call(arguments).filter(function (a) {return a !== undefined; });
+SolidityFunction.prototype.call = function() {
+    var args = Array.prototype.slice.call(arguments).filter(function(a) { return a !== undefined; });
     var callback = this.extractCallback(args);
     var defaultBlock = this.extractDefaultBlock(args);
     var payload = this.toPayload(args);
@@ -139,20 +139,11 @@ SolidityFunction.prototype.call = function () {
         return this.unpackOutput(output);
     }
 
-console.log("SolidityFunction Contract call data:", payload);
     var self = this;
-    this._mc.call(payload, defaultBlock, function (error, output) {
+    this._mc.call(payload, defaultBlock, function(error, output) {
         if (error) return callback(error, null);
 
-        var unpacked = null;
-        try {
-            unpacked = self.unpackOutput(output);
-        }
-        catch (e) {
-            error = e;
-        }
-
-        callback(error, unpacked);
+        callback(error, output);
     });
 };
 
@@ -161,8 +152,8 @@ console.log("SolidityFunction Contract call data:", payload);
  *
  * @method sendTransaction
  */
-SolidityFunction.prototype.sendTransaction = function () {
-    var args = Array.prototype.slice.call(arguments).filter(function (a) {return a !== undefined; });
+SolidityFunction.prototype.sendTransaction = function() {
+    var args = Array.prototype.slice.call(arguments).filter(function(a) { return a !== undefined; });
     var callback = this.extractCallback(args);
     var payload = this.toPayload(args);
 
@@ -183,7 +174,7 @@ SolidityFunction.prototype.sendTransaction = function () {
  *
  * @method estimateGas
  */
-SolidityFunction.prototype.estimateGas = function () {
+SolidityFunction.prototype.estimateGas = function() {
     var args = Array.prototype.slice.call(arguments);
     var callback = this.extractCallback(args);
     var payload = this.toPayload(args);
@@ -201,7 +192,7 @@ SolidityFunction.prototype.estimateGas = function () {
  * @method getData
  * @return {String} the encoded data
  */
-SolidityFunction.prototype.getData = function () {
+SolidityFunction.prototype.getData = function() {
     var args = Array.prototype.slice.call(arguments);
     var payload = this.toPayload(args);
 
@@ -214,7 +205,7 @@ SolidityFunction.prototype.getData = function () {
  * @method displayName
  * @return {String} display name of the function
  */
-SolidityFunction.prototype.displayName = function () {
+SolidityFunction.prototype.displayName = function() {
     return utils.extractDisplayName(this._name);
 };
 
@@ -224,7 +215,7 @@ SolidityFunction.prototype.displayName = function () {
  * @method typeName
  * @return {String} type name of the function
  */
-SolidityFunction.prototype.typeName = function () {
+SolidityFunction.prototype.typeName = function() {
     return utils.extractTypeName(this._name);
 };
 
@@ -234,7 +225,7 @@ SolidityFunction.prototype.typeName = function () {
  * @method request
  * @returns {Object}
  */
-SolidityFunction.prototype.request = function () {
+SolidityFunction.prototype.request = function() {
     var args = Array.prototype.slice.call(arguments);
     var callback = this.extractCallback(args);
     var payload = this.toPayload(args);
@@ -253,7 +244,7 @@ SolidityFunction.prototype.request = function () {
  *
  * @method execute
  */
-SolidityFunction.prototype.execute = function () {
+SolidityFunction.prototype.execute = function() {
     var transaction = !this._constant;
 
     // send transaction
@@ -271,7 +262,7 @@ SolidityFunction.prototype.execute = function () {
  * @method attachToContract
  * @param {Contract}
  */
-SolidityFunction.prototype.attachToContract = function (contract) {
+SolidityFunction.prototype.attachToContract = function(contract) {
     var execute = this.execute.bind(this);
     execute.request = this.request.bind(this);
     execute.call = this.call.bind(this);

--- a/lib/solidity/formatters.js
+++ b/lib/solidity/formatters.js
@@ -38,7 +38,7 @@ var SolidityParam = require('./param');
  * @param {String|Number|BigNumber} value that needs to be formatted
  * @returns {SolidityParam}
  */
-var formatInputInt = function (value) {
+var formatInputInt = function(value) {
     BigNumber.config(config.MC_BIGNUMBER_ROUNDING_MODE);
     var result = utils.padLeft(utils.toTwosComplement(value).toString(16), 64);
     return new SolidityParam(result);
@@ -51,7 +51,7 @@ var formatInputInt = function (value) {
  * @param {String}
  * @returns {SolidityParam}
  */
-var formatInputBytes = function (value) {
+var formatInputBytes = function(value) {
     var result = utils.toHex(value).substr(2);
     var l = Math.floor((result.length + 63) / 64);
     result = utils.padRight(result, l * 64);
@@ -65,7 +65,7 @@ var formatInputBytes = function (value) {
  * @param {String}
  * @returns {SolidityParam}
  */
-var formatInputDynamicBytes = function (value) {
+var formatInputDynamicBytes = function(value) {
     var result = utils.toHex(value).substr(2);
     var length = result.length / 2;
     var l = Math.floor((result.length + 63) / 64);
@@ -80,7 +80,7 @@ var formatInputDynamicBytes = function (value) {
  * @param {String}
  * @returns {SolidityParam}
  */
-var formatInputString = function (value) {
+var formatInputString = function(value) {
     var result = utils.fromUtf8(value).substr(2);
     var length = result.length / 2;
     var l = Math.floor((result.length + 63) / 64);
@@ -95,7 +95,7 @@ var formatInputString = function (value) {
  * @param {Boolean}
  * @returns {SolidityParam}
  */
-var formatInputBool = function (value) {
+var formatInputBool = function(value) {
     var result = '000000000000000000000000000000000000000000000000000000000000000' + (value ? '1' : '0');
     return new SolidityParam(result);
 };
@@ -108,7 +108,7 @@ var formatInputBool = function (value) {
  * @param {String|Number|BigNumber}
  * @returns {SolidityParam}
  */
-var formatInputReal = function (value) {
+var formatInputReal = function(value) {
     return formatInputInt(new BigNumber(value).times(new BigNumber(2).pow(128)));
 };
 
@@ -120,7 +120,7 @@ var formatInputReal = function (value) {
  * @param {Object}
  * @returns {SolidityParam}
  */
-var formatInputTuple = function (value) {
+var formatInputTuple = function(value) {
     return formatInputInt(new BigNumber(value).times(new BigNumber(2).pow(128)));
 };
 
@@ -131,7 +131,7 @@ var formatInputTuple = function (value) {
  * @param {String} value is hex format
  * @returns {Boolean} true if it is negative, otherwise false
  */
-var signedIsNegative = function (value) {
+var signedIsNegative = function(value) {
     return (new BigNumber(value.substr(0, 1), 16).toString(2).substr(0, 1)) === '1';
 };
 
@@ -142,7 +142,7 @@ var signedIsNegative = function (value) {
  * @param {SolidityParam} param
  * @returns {BigNumber} right-aligned output bytes formatted to big number
  */
-var formatOutputInt = function (param) {
+var formatOutputInt = function(param) {
     var value = param.staticPart() || "0";
 
     // check if it's negative number
@@ -160,7 +160,7 @@ var formatOutputInt = function (param) {
  * @param {SolidityParam}
  * @returns {BigNumeber} right-aligned output bytes formatted to uint
  */
-var formatOutputUInt = function (param) {
+var formatOutputUInt = function(param) {
     var value = param.staticPart() || "0";
     return new BigNumber(value, 16);
 };
@@ -172,7 +172,7 @@ var formatOutputUInt = function (param) {
  * @param {SolidityParam}
  * @returns {BigNumber} input bytes formatted to real
  */
-var formatOutputReal = function (param) {
+var formatOutputReal = function(param) {
     return formatOutputInt(param).dividedBy(new BigNumber(2).pow(128));
 };
 
@@ -183,7 +183,7 @@ var formatOutputReal = function (param) {
  * @param {SolidityParam}
  * @returns {BigNumber} input bytes formatted to ureal
  */
-var formatOutputUReal = function (param) {
+var formatOutputUReal = function(param) {
     return formatOutputUInt(param).dividedBy(new BigNumber(2).pow(128));
 };
 
@@ -194,7 +194,7 @@ var formatOutputUReal = function (param) {
  * @param {SolidityParam}
  * @returns {Boolean} right-aligned input bytes formatted to bool
  */
-var formatOutputBool = function (param) {
+var formatOutputBool = function(param) {
     return param.staticPart() === '0000000000000000000000000000000000000000000000000000000000000001' ? true : false;
 };
 
@@ -206,7 +206,7 @@ var formatOutputBool = function (param) {
  * @param {String} name type name
  * @returns {String} hex string
  */
-var formatOutputBytes = function (param, name) {
+var formatOutputBytes = function(param, name) {
     var matches = name.match(/^bytes([0-9]*)/);
     var size = parseInt(matches[1]);
     return '0x' + param.staticPart().slice(0, 2 * size);
@@ -219,7 +219,7 @@ var formatOutputBytes = function (param, name) {
  * @param {SolidityParam} left-aligned hex representation of string
  * @returns {String} hex string
  */
-var formatOutputDynamicBytes = function (param) {
+var formatOutputDynamicBytes = function(param) {
     var length = (new BigNumber(param.dynamicPart().slice(0, 64), 16)).toNumber() * 2;
     return '0x' + param.dynamicPart().substr(64, length);
 };
@@ -231,7 +231,7 @@ var formatOutputDynamicBytes = function (param) {
  * @param {SolidityParam} left-aligned hex representation of string
  * @returns {String} ascii string
  */
-var formatOutputString = function (param) {
+var formatOutputString = function(param) {
     var length = (new BigNumber(param.dynamicPart().slice(0, 64), 16)).toNumber() * 2;
     return utils.toUtf8(param.dynamicPart().substr(64, length));
 };
@@ -243,7 +243,7 @@ var formatOutputString = function (param) {
  * @param {SolidityParam} right-aligned input bytes
  * @returns {String} address
  */
-var formatOutputAddress = function (param) {
+var formatOutputAddress = function(param) {
     var value = param.staticPart();
     return "0x" + value.slice(value.length - 40, value.length);
 };
@@ -257,17 +257,17 @@ var formatOutputAddress = function (param) {
  * @param {string} structName
  * @return {{type: string, name: *}}
  */
-var formatOutputTuple = function (structName) {
+var formatOutputTuple = function(structName) {
     // var value = param.staticPart();
     // return "0x" + value.slice(value.length - 40, value.length);
     var type = 'tuple';
 
-    if (structName.indexOf('[]') > -1) {
+    if (structName.toString().indexOf('[]') > -1) {
         type = 'tuple[]';
         structName = structName.slice(0, -2);
     }
 
-    return {type: type, name: structName};
+    return { type: type, name: structName };
 };
 
 module.exports = {


### PR DESCRIPTION
看起来修改很多，实际上是自动format代码布局搞的

修改点有两处
lib/solidity/formatters.js  formatOutputTuple函数，将对象字符化后执行，否则返回tuple在这里会崩溃

lib/chain3/function.js SolidityFunction.prototype.call 将output raw data交给callback,在外部自己处理，因为现有的chain3不支持结构体和元组数据的解析，我们自己在外面用以太的包来处理数据分析